### PR TITLE
Update to node 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -55,12 +55,12 @@ runs:
   using: composite
   steps:
     - name: Checking node version
-      id: node-version-above-18
+      id: node-version-above-20
       shell: bash
       run: bash etc/compare-node-version.sh
       continue-on-error: true
     - uses: actions/setup-node@v4
-      if: ${{ steps.node-version-above-18.conclusion == 'failure' }}
+      if: ${{ steps.node-version-above-20.conclusion == 'failure' }}
       with:
         node-version: 20
     - uses: actions/cache@v4

--- a/action.yml
+++ b/action.yml
@@ -63,7 +63,7 @@ runs:
       if: ${{ steps.node-version-above-18.conclusion == 'failure' }}
       with:
         node-version: '18.x'
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       if: ${{ inputs.cache == 'true' }}
       env: { cache-name: firebase-app-distribution-action }
       with:

--- a/action.yml
+++ b/action.yml
@@ -62,7 +62,7 @@ runs:
     - uses: actions/setup-node@v4
       if: ${{ steps.node-version-above-18.conclusion == 'failure' }}
       with:
-        node-version: '18.x'
+        node-version: 20
     - uses: actions/cache@v4
       if: ${{ inputs.cache == 'true' }}
       env: { cache-name: firebase-app-distribution-action }

--- a/etc/compare-node-version.sh
+++ b/etc/compare-node-version.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 nodever="$(node --version)"
 currentver="${nodever:1}"
-requiredver="18.0.0"
+requiredver="20.0.0"
 if [ "$(printf '%s\n' "$requiredver" "$currentver" | sort -V | head -n1)" = "$requiredver" ]; then 
   exit 0
 else


### PR DESCRIPTION
We have a warning in our usage of this action that is uses the deprecated `actions/cache@v3` version.

> The following actions use a deprecated Node.js version and will be forced to run on node20: actions/cache@v3. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/

So I updated the cache to v4 and also Node to 20 in general. Not sure if this is the right way to do it though, but I tried 🤷 